### PR TITLE
encoder: reuse the caller's allocated pixels

### DIFF
--- a/examples/png2avif.rs
+++ b/examples/png2avif.rs
@@ -1,19 +1,20 @@
 use std::env;
 use std::io::{self, Write};
 
+use image::DynamicImage;
+
 fn main() {
     let input = env::args().nth(1).expect("input png");
+    let img = image::open(&input).expect("opening");
 
-    let img = match image::open(&input).expect("opening") {
-        image::DynamicImage::ImageRgb8(img) => img,
+    let data = match img {
+        DynamicImage::ImageRgb8(img) => {
+            let rgb = img.as_flat_samples();
+            libavif::encode_rgb8(img.width(), img.height(), rgb.as_slice()).expect("encoding avif")
+        }
         _ => panic!("image type not supported"),
     };
 
-    let rows = img
-        .rows()
-        .map(|row| row.map(|c| (c[0], c[1], c[2])).collect());
-
-    let data = libavif::encode_rgb(img.width(), img.height(), rows, 0).expect("encoding avif");
     io::stdout()
         .write_all(data.as_slice())
         .expect("output avif");

--- a/libavif-image/src/lib.rs
+++ b/libavif-image/src/lib.rs
@@ -25,16 +25,14 @@ pub fn read(buf: &[u8]) -> Result<DynamicImage, String> {
 
 /// Save an image into an AVIF file
 pub fn save(img: &DynamicImage) -> Result<AvifData, String> {
-    let img = match img {
-        DynamicImage::ImageRgb8(img) => img,
+    let data = match img {
+        DynamicImage::ImageRgb8(img) => {
+            let rgb = img.as_flat_samples();
+            libavif::encode_rgb8(img.width(), img.height(), rgb.as_slice())
+                .map_err(|e| format!("encoding AVIF: {:?}", e))?
+        }
         _ => return Err("image type not supported".into()),
     };
 
-    let rows = img
-        .rows()
-        .map(|row| row.map(|c| (c[0], c[1], c[2])).collect());
-
-    let data = libavif::encode_rgb(img.width(), img.height(), rows, 0)
-        .map_err(|e| format!("encoding AVIF: {:?}", e))?;
     Ok(data)
 }


### PR DESCRIPTION
This changes the encoder to use the already allocated pixels passed by the caller instead of allocating new avifRGBImage pixels