### PR TITLE
Avoid copying the encoded image bytes when returning them

### DIFF
--- a/examples/png2avif.rs
+++ b/examples/png2avif.rs
@@ -13,6 +13,8 @@ fn main() {
         .rows()
         .map(|row| row.map(|c| (c[0], c[1], c[2])).collect());
 
-    let buf = libavif::encode_rgb(img.width(), img.height(), rows, 0).expect("encoding avif");
-    io::stdout().write_all(&buf).expect("output avif");
+    let data = libavif::encode_rgb(img.width(), img.height(), rows, 0).expect("encoding avif");
+    io::stdout()
+        .write_all(data.as_slice())
+        .expect("output avif");
 }

--- a/libavif-image/src/lib.rs
+++ b/libavif-image/src/lib.rs
@@ -6,6 +6,7 @@
 use image::{DynamicImage, RgbImage};
 
 pub use libavif::is_avif;
+use libavif::AvifData;
 
 /// Read data that is in an AVIF file and load it into an image
 pub fn read(buf: &[u8]) -> Result<DynamicImage, String> {
@@ -23,7 +24,7 @@ pub fn read(buf: &[u8]) -> Result<DynamicImage, String> {
 }
 
 /// Save an image into an AVIF file
-pub fn save(img: &DynamicImage) -> Result<Vec<u8>, String> {
+pub fn save(img: &DynamicImage) -> Result<AvifData, String> {
     let img = match img {
         DynamicImage::ImageRgb8(img) => img,
         _ => return Err("image type not supported".into()),

--- a/libavif-image/tests/check.rs
+++ b/libavif-image/tests/check.rs
@@ -10,9 +10,9 @@ fn images() {
         let height = image.height();
 
         let avif = libavif_image::save(&image).expect("encode avif");
-        assert!(libavif_image::is_avif(&avif));
+        assert!(libavif_image::is_avif(avif.as_slice()));
 
-        let image2 = libavif_image::read(&avif).expect("decode avif");
+        let image2 = libavif_image::read(avif.as_slice()).expect("decode avif");
         assert_eq!(width, image2.width());
         assert_eq!(height, image2.height());
     }

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,0 +1,55 @@
+use std::marker::PhantomData;
+use std::slice;
+
+use libavif_sys as sys;
+
+pub struct AvifData<'a> {
+    owned: bool,
+    inner: sys::avifRWData,
+
+    phantom: PhantomData<&'a [u8]>,
+}
+
+impl<'a> AvifData<'a> {
+    pub fn new(b: &'a [u8]) -> Self {
+        Self {
+            owned: true,
+            inner: sys::avifRWData {
+                data: b.as_ptr() as *mut u8,
+                size: b.len(),
+            },
+            phantom: PhantomData,
+        }
+    }
+
+    /// Extracts a slice containg the entire data without doing clones or allocation.
+    pub fn as_slice(&'a self) -> &'a [u8] {
+        unsafe { slice::from_raw_parts(self.inner.data, self.inner.size) }
+    }
+
+    /// Converts `self` into a new vector by cloning the entire data.
+    pub fn to_vec(&self) -> Vec<u8> {
+        self.as_slice().to_vec()
+    }
+}
+
+impl<'a> From<sys::avifRWData> for AvifData<'a> {
+    fn from(data: sys::avifRWData) -> Self {
+        Self {
+            owned: false,
+            inner: data,
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl Drop for AvifData<'_> {
+    fn drop(&mut self) {
+        if !self.owned {
+            // pixels were allocated by libavif
+            unsafe {
+                sys::avifRWDataFree(&mut self.inner);
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,11 @@
 #![allow(clippy::many_single_char_names)]
 
 use std::io;
-use std::slice;
 
+pub use self::data::AvifData;
 use libavif_sys as sys;
+
+mod data;
 
 pub struct RgbPixels {
     rgb: sys::avifRGBImage,
@@ -99,7 +101,7 @@ pub fn encode_rgb<Rows: Iterator<Item = Vec<(u8, u8, u8)>>>(
     height: u32,
     rows: Rows,
     _q: u32,
-) -> io::Result<Vec<u8>> {
+) -> io::Result<AvifData<'static>> {
     unsafe {
         let image = sys::avifImageCreate(width as _, height as _, 8, sys::AVIF_PIXEL_FORMAT_YUV444);
         sys::avifImageAllocatePlanes(image, sys::AVIF_PLANES_YUV as _);
@@ -141,10 +143,6 @@ pub fn encode_rgb<Rows: Iterator<Item = Vec<(u8, u8, u8)>>>(
             ));
         }
 
-        let v = slice::from_raw_parts(raw.data, raw.size).to_vec();
-
-        sys::avifRWDataFree(&mut raw);
-
-        Ok(v)
+        Ok(AvifData::from(raw))
     }
 }


### PR DESCRIPTION
Creates a safe wrapper around avifRWData and uses it to return the encoded avif image bytes.

This avoids having to call .to_vec() to get the bytes returned by the encoder, which avoids copying data.