### PR TITLE
feat: add to and from slice conversions to RgbPixels

### DIFF
--- a/examples/avif2png.rs
+++ b/examples/avif2png.rs
@@ -1,7 +1,7 @@
 use std::env;
 use std::fs;
 
-use image::{DynamicImage, ImageOutputFormat, RgbImage};
+use image::{DynamicImage, ImageBuffer, ImageOutputFormat};
 
 fn main() {
     let input = env::args().nth(1).expect("input filename");
@@ -10,16 +10,10 @@ fn main() {
     let pixels = libavif::decode_rgb(&buf).expect("decoding");
     eprintln!("w={}, h={}", pixels.width(), pixels.height());
 
-    let mut img = RgbImage::new(pixels.width(), pixels.height());
+    let buffer = ImageBuffer::from_vec(pixels.width(), pixels.height(), pixels.to_vec())
+        .expect("pixels doesn't fit image::ImageBuffer");
 
-    for y in 0..img.height() {
-        for x in 0..img.width() {
-            let (r, g, b, _a) = pixels.pixel(x, y);
-            img.put_pixel(x, y, [r, g, b].into());
-        }
-    }
-
-    let img = DynamicImage::ImageRgb8(img);
+    let img = DynamicImage::ImageRgba8(buffer);
     img.write_to(&mut std::io::stdout(), ImageOutputFormat::Png)
         .expect("out");
 }

--- a/libavif-image/src/lib.rs
+++ b/libavif-image/src/lib.rs
@@ -3,7 +3,7 @@
 //!
 //! Converts to and from YUV (`image` only does RGB).
 
-use image::{DynamicImage, RgbImage};
+use image::{DynamicImage, ImageBuffer};
 
 pub use libavif::is_avif;
 use libavif::AvifData;
@@ -11,16 +11,10 @@ use libavif::AvifData;
 /// Read data that is in an AVIF file and load it into an image
 pub fn read(buf: &[u8]) -> Result<DynamicImage, String> {
     let pixels = libavif::decode_rgb(buf).map_err(|e| format!("decoding AVIF: {}", e))?;
-    let mut img = RgbImage::new(pixels.width(), pixels.height());
+    let buffer = ImageBuffer::from_vec(pixels.width(), pixels.height(), pixels.to_vec())
+        .expect("pixels doesn't fit image::ImageBuffer");
 
-    for y in 0..img.height() {
-        for x in 0..img.width() {
-            let (r, g, b, _a) = pixels.pixel(x, y);
-            img.put_pixel(x, y, [r, g, b].into());
-        }
-    }
-
-    Ok(DynamicImage::ImageRgb8(img))
+    Ok(DynamicImage::ImageRgba8(buffer))
 }
 
 /// Save an image into an AVIF file

--- a/src/image.rs
+++ b/src/image.rs
@@ -89,6 +89,13 @@ impl<'a> From<sys::avifRGBImage> for RgbPixels<'a> {
     }
 }
 
+impl<'a> std::ops::Deref for RgbPixels<'a> {
+    type Target = [u8];
+    fn deref(&self) -> &Self::Target {
+        self.as_slice()
+    }
+}
+
 impl Drop for RgbPixels<'_> {
     fn drop(&mut self) {
         if !self.owned {

--- a/src/image.rs
+++ b/src/image.rs
@@ -1,18 +1,18 @@
 use libavif_sys as sys;
 
 pub struct RgbPixels {
-    pub(crate) rgb: sys::avifRGBImage,
+    pub(crate) inner: sys::avifRGBImage,
 }
 
 impl RgbPixels {
     /// width of the image in pixels
     pub fn width(&self) -> u32 {
-        self.rgb.width
+        self.inner.width
     }
 
     /// height of the image in pixels
     pub fn height(&self) -> u32 {
-        self.rgb.height
+        self.inner.height
     }
 
     pub fn pixel(&self, x: u32, y: u32) -> (u8, u8, u8, u8) {
@@ -20,8 +20,8 @@ impl RgbPixels {
         assert!(y < self.height());
 
         unsafe {
-            let pixels = self.rgb.pixels;
-            let row_bytes = self.rgb.rowBytes as usize;
+            let pixels = self.inner.pixels;
+            let row_bytes = self.inner.rowBytes as usize;
             let rgb = pixels.add((4 * x as usize) + (row_bytes * y as usize));
             let r = *rgb.add(0);
             let g = *rgb.add(1);
@@ -35,7 +35,7 @@ impl RgbPixels {
 impl Drop for RgbPixels {
     fn drop(&mut self) {
         unsafe {
-            sys::avifRGBImageFreePixels(&mut self.rgb as *mut sys::avifRGBImage);
+            sys::avifRGBImageFreePixels(&mut self.inner as *mut sys::avifRGBImage);
         }
     }
 }

--- a/src/image.rs
+++ b/src/image.rs
@@ -1,10 +1,42 @@
+use std::marker::PhantomData;
+use std::slice;
+
 use libavif_sys as sys;
 
-pub struct RgbPixels {
-    pub(crate) inner: sys::avifRGBImage,
+pub struct RgbPixels<'a> {
+    owned: bool,
+    inner: sys::avifRGBImage,
+
+    phantom: PhantomData<&'a [u8]>,
 }
 
-impl RgbPixels {
+impl<'a> RgbPixels<'a> {
+    pub fn new(width: u32, height: u32, rgb: &'a [u8]) -> Self {
+        let (stride, format) = if (width * height * 3) as usize == rgb.len() {
+            // RGB
+            (3, sys::AVIF_RGB_FORMAT_RGB)
+        } else if (width * height * 4) as usize == rgb.len() {
+            // RGBA
+            (4, sys::AVIF_RGB_FORMAT_RGBA)
+        } else {
+            panic!("invalid rgb len")
+        };
+
+        Self {
+            owned: true,
+            inner: sys::avifRGBImage {
+                width,
+                height,
+                depth: 8,
+                format,
+                chromaUpsampling: sys::AVIF_CHROMA_UPSAMPLING_BILINEAR,
+                pixels: rgb.as_ptr() as *mut u8,
+                rowBytes: stride * width,
+            },
+            phantom: PhantomData,
+        }
+    }
+
     /// width of the image in pixels
     pub fn width(&self) -> u32 {
         self.inner.width
@@ -30,12 +62,40 @@ impl RgbPixels {
             (r, g, b, a)
         }
     }
+
+    /// Extracts a slice containg all of the pixels without doing clones or allocation.
+    pub fn as_slice(&'a self) -> &'a [u8] {
+        let size = self.inner.rowBytes * self.height();
+        unsafe { slice::from_raw_parts(self.inner.pixels, size as usize) }
+    }
+
+    /// Converts `self` into a new vector by cloning all of the pixels.
+    pub fn to_vec(&self) -> Vec<u8> {
+        self.as_slice().to_vec()
+    }
+
+    pub(crate) unsafe fn inner_mut(&mut self) -> &mut sys::avifRGBImage {
+        &mut self.inner
+    }
 }
 
-impl Drop for RgbPixels {
+impl<'a> From<sys::avifRGBImage> for RgbPixels<'a> {
+    fn from(rgb: sys::avifRGBImage) -> Self {
+        Self {
+            owned: false,
+            inner: rgb,
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl Drop for RgbPixels<'_> {
     fn drop(&mut self) {
-        unsafe {
-            sys::avifRGBImageFreePixels(&mut self.inner as *mut sys::avifRGBImage);
+        if !self.owned {
+            // pixels were allocated by libavif
+            unsafe {
+                sys::avifRGBImageFreePixels(&mut self.inner as *mut sys::avifRGBImage);
+            }
         }
     }
 }

--- a/src/image.rs
+++ b/src/image.rs
@@ -1,0 +1,41 @@
+use libavif_sys as sys;
+
+pub struct RgbPixels {
+    pub(crate) rgb: sys::avifRGBImage,
+}
+
+impl RgbPixels {
+    /// width of the image in pixels
+    pub fn width(&self) -> u32 {
+        self.rgb.width
+    }
+
+    /// height of the image in pixels
+    pub fn height(&self) -> u32 {
+        self.rgb.height
+    }
+
+    pub fn pixel(&self, x: u32, y: u32) -> (u8, u8, u8, u8) {
+        assert!(x < self.width());
+        assert!(y < self.height());
+
+        unsafe {
+            let pixels = self.rgb.pixels;
+            let row_bytes = self.rgb.rowBytes as usize;
+            let rgb = pixels.add((4 * x as usize) + (row_bytes * y as usize));
+            let r = *rgb.add(0);
+            let g = *rgb.add(1);
+            let b = *rgb.add(2);
+            let a = *rgb.add(3);
+            (r, g, b, a)
+        }
+    }
+}
+
+impl Drop for RgbPixels {
+    fn drop(&mut self) {
+        unsafe {
+            sys::avifRGBImageFreePixels(&mut self.rgb as *mut sys::avifRGBImage);
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,49 +3,11 @@
 use std::io;
 
 pub use self::data::AvifData;
+pub use self::image::RgbPixels;
 use libavif_sys as sys;
 
 mod data;
-
-pub struct RgbPixels {
-    rgb: sys::avifRGBImage,
-}
-
-impl RgbPixels {
-    /// width of the image in pixels
-    pub fn width(&self) -> u32 {
-        self.rgb.width
-    }
-
-    /// height of the image in pixels
-    pub fn height(&self) -> u32 {
-        self.rgb.height
-    }
-
-    pub fn pixel(&self, x: u32, y: u32) -> (u8, u8, u8, u8) {
-        assert!(x < self.width());
-        assert!(y < self.height());
-
-        unsafe {
-            let pixels = self.rgb.pixels;
-            let row_bytes = self.rgb.rowBytes as usize;
-            let rgb = pixels.add((4 * x as usize) + (row_bytes * y as usize));
-            let r = *rgb.add(0);
-            let g = *rgb.add(1);
-            let b = *rgb.add(2);
-            let a = *rgb.add(3);
-            (r, g, b, a)
-        }
-    }
-}
-
-impl Drop for RgbPixels {
-    fn drop(&mut self) {
-        unsafe {
-            sys::avifRGBImageFreePixels(&mut self.rgb as *mut sys::avifRGBImage);
-        }
-    }
-}
+mod image;
 
 /// Very efficiently detects AVIF files
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@ pub fn decode_rgb(avif_bytes: &[u8]) -> io::Result<RgbPixels> {
         sys::avifImageYUVToRGB(image, raw_rgb);
         sys::avifImageDestroy(image);
 
-        Ok(RgbPixels { rgb })
+        Ok(RgbPixels { inner: rgb })
     }
 }
 


### PR DESCRIPTION
This is the first step into extending the encoder and decoder to make them accept all or at least most color formats the libavif library already accepts.