### PR TITLE
tests: verify that the decoded avif matches the original image

### DIFF
--- a/libavif-image/tests/check.rs
+++ b/libavif-image/tests/check.rs
@@ -6,15 +6,12 @@ fn images() {
         let path = format!("tests/{}", non_avifs);
         let image = image::open(path).expect("image::open non avif input");
 
-        let width = image.width();
-        let height = image.height();
-
         let avif = libavif_image::save(&image).expect("encode avif");
         assert!(libavif_image::is_avif(avif.as_slice()));
 
         let image2 = libavif_image::read(avif.as_slice()).expect("decode avif");
-        assert_eq!(width, image2.width());
-        assert_eq!(height, image2.height());
+        assert_eq!(image.width(), image2.width());
+        assert_eq!(image.height(), image2.height());
 
         let image = image.to_rgba();
         let image2 = image2.to_rgba();
@@ -26,11 +23,11 @@ fn images() {
                 pix1.channels()
                     .iter()
                     .zip(pix2.channels().iter())
-                    .map(|(p1, p2)| ((*p1 as i64) - (*p2 as i64)).abs() as u64)
+                    .map(|(p1, p2)| (p1.max(p2) - p1.min(p2)) as u64)
                     .sum::<u64>()
             })
             .sum::<u64>()
             / image.pixels().count() as u64;
-        assert!(diff < 20);
+        assert!(diff < 16);
     }
 }

--- a/libavif-image/tests/check.rs
+++ b/libavif-image/tests/check.rs
@@ -1,4 +1,4 @@
-use image::GenericImageView;
+use image::{GenericImageView, Pixel};
 
 #[test]
 fn images() {
@@ -15,5 +15,22 @@ fn images() {
         let image2 = libavif_image::read(avif.as_slice()).expect("decode avif");
         assert_eq!(width, image2.width());
         assert_eq!(height, image2.height());
+
+        let image = image.to_rgba();
+        let image2 = image2.to_rgba();
+
+        let diff = image
+            .pixels()
+            .zip(image2.pixels())
+            .map(|(pix1, pix2)| {
+                pix1.channels()
+                    .iter()
+                    .zip(pix2.channels().iter())
+                    .map(|(p1, p2)| ((*p1 as i64) - (*p2 as i64)).abs() as u64)
+                    .sum::<u64>()
+            })
+            .sum::<u64>()
+            / image.pixels().count() as u64;
+        assert!(diff < 20);
     }
 }


### PR DESCRIPTION
This improves #5 by trying to compare the original image to the one which went through the encoder and the decoder and checking that the difference isn't too big between the two.