### PR TITLE
Add support for Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,7 @@ jobs:
           - linux / beta
           - linux / nightly
           - macOS / stable
+          - windows / stable
           - "feat.: codec-aom"
           - linux / 1.36.0
 
@@ -87,6 +88,8 @@ jobs:
 
           - name: macOS / stable
             os: macOS-latest
+          - name: windows / stable
+            os: windows-latest
 
           - name: "feat.: codec-aom"
             features: "--no-default-features --features codec-aom"
@@ -98,7 +101,7 @@ jobs:
           submodules: true
 
       - name: Install dependencies (linux)
-        if: matrix.os != 'macOS-latest'
+        if: (matrix.os || 'ubuntu-20.04') == 'ubuntu-20.04'
         run: |
           DEBIAN_FRONTEND=noninteractive sudo apt-get update
           DEBIAN_FRONTEND=noninteractive sudo apt-get install -y ninja-build nasm meson
@@ -107,6 +110,16 @@ jobs:
         if: matrix.os == 'macOS-latest'
         run: |
           brew install ninja nasm meson
+
+      - name: Install dependencies (windows)
+        if: matrix.os == 'windows-latest'
+        run: |
+          choco install -y ninja
+          pip install meson
+
+      - name: Install nasm (windows)
+        if: matrix.os == 'windows-latest'
+        uses: ilammy/setup-nasm@v1
 
       - name: Install rust
         uses: actions-rs/toolchain@v1

--- a/libavif-sys/build.rs
+++ b/libavif-sys/build.rs
@@ -1,15 +1,17 @@
 use std::env;
 #[cfg(feature = "codec-rav1e")]
 use std::fs;
+use std::path::Path;
 #[cfg(feature = "codec-dav1d")]
 use std::process::Command;
 
 use cmake::Config;
 
 fn main() {
+    let out_dir_ = env::var("OUT_DIR").unwrap();
+    let out_dir = Path::new(&out_dir_);
     let mut _build_paths = String::new();
     let mut avif = Config::new("libavif");
-    let out_dir = env::var("OUT_DIR").unwrap();
 
     #[cfg(feature = "codec-aom")]
     {
@@ -33,13 +35,15 @@ fn main() {
 
     #[cfg(feature = "codec-rav1e")]
     {
-        let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
-        fs::create_dir_all(&format!("{}/include/rav1e", out_dir)).expect("mkdir");
+        let crate_dir_ = env::var("CARGO_MANIFEST_DIR").unwrap();
+        let crate_dir = Path::new(&crate_dir_);
+        fs::create_dir_all(out_dir.join("include").join("rav1e")).expect("mkdir");
         fs::copy(
-            &format!("{}/rav1e.h", crate_dir),
-            &format!("{}/include/rav1e/rav1e.h", out_dir),
+            crate_dir.join("rav1e.h"),
+            out_dir.join("include").join("rav1e").join("rav1e.h"),
         )
         .expect("copy rav1e.h");
+
         avif.define("AVIF_CODEC_RAV1E", "1")
             .define("AVIF_CODEC_LIBRARIES", "rav1e")
             .define("RAV1E_LIBRARY", "-rav1e");
@@ -47,10 +51,11 @@ fn main() {
 
     #[cfg(feature = "codec-dav1d")]
     {
-        let build_path = out_dir.clone() + "/dav1d";
+        let build_path = out_dir.join("dav1d");
         {
             println!("cargo:rustc-link-lib=static=dav1d");
-            println!("cargo:rustc-link-search=native={}", build_path);
+            println!("cargo:rustc-link-search=native={}", build_path.display());
+
             let s = Command::new("meson")
                 .arg("--default-library=static")
                 .arg("--buildtype")
@@ -58,10 +63,11 @@ fn main() {
                 .arg(&build_path)
                 .arg("dav1d")
                 .arg("--prefix")
-                .arg(&format!("{}/install", build_path))
+                .arg(build_path.join("install"))
                 .status()
                 .expect("meson");
             assert!(s.success());
+
             let s = Command::new("ninja")
                 .current_dir(&build_path)
                 .arg("install")
@@ -69,8 +75,12 @@ fn main() {
                 .expect("ninja");
             assert!(s.success());
         }
-        _build_paths += &format!("{}/install;", build_path);
-        println!("cargo:rustc-link-search=native={}/src", build_path);
+        _build_paths.push_str(build_path.join("install").to_str().unwrap());
+        _build_paths.push(';');
+        println!(
+            "cargo:rustc-link-search=native={}",
+            build_path.join("src").display()
+        );
         avif.define("AVIF_CODEC_DAV1D", "1");
     }
 
@@ -87,13 +97,14 @@ fn main() {
     .unwrap();
 
     let mut avif_built = avif
-        .define("CMAKE_PREFIX_PATH", &_build_paths)
+        .define("CMAKE_PREFIX_PATH", _build_paths)
         .define("BUILD_SHARED_LIBS", "0")
         .env("PKG_CONFIG_PATH", local_pc_files)
         .profile("Release")
         .build();
+
     avif_built.push("lib");
     println!("cargo:rustc-link-search=native={}", avif_built.display());
     println!("cargo:rustc-link-lib=static=avif");
-    println!("cargo:outdir={}", out_dir);
+    println!("cargo:outdir={}", out_dir.display());
 }


### PR DESCRIPTION
In https://github.com/ArturKovacs/emulsion/pull/116 we realized `libavif` should also support Windows.

I started working on it, but at the moment it says it can't find dav1d. I'll investigate this further when I have time to spawn a Windows VM, in the meantime I'm opening this as a Draft PR.