### PR TITLE
Separate out libaom build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,8 @@
 [submodule "libavif-sys/libavif"]
 	path = libavif-sys/libavif
 	url = https://github.com/AOMediaCodec/libavif.git
-[submodule "libavif-sys/aom"]
-	path = libavif-sys/aom
+[submodule "libaom-sys/vendor"]
+	path = libaom-sys/vendor
 	url = https://aomedia.googlesource.com/aom
 [submodule "libavif-sys/dav1d"]
 	path = libavif-sys/dav1d

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,5 +34,6 @@ features = ["codec-aom", "__internal_aom_generic_target"]
 [workspace]
 members = [
   "libavif-image",
-  "libavif-sys"
+  "libavif-sys",
+  "libaom-sys",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,14 +22,12 @@ codec-rav1e = ["libavif-sys/codec-rav1e"]
 codec-dav1d = ["libavif-sys/codec-dav1d"]
 codec-aom = ["libavif-sys/codec-aom"]
 
-__internal_aom_generic_target = ["libavif-sys/__internal_aom_generic_target"]
-
 [profile.dev]
 opt-level = 2
 
 [package.metadata.docs.rs]
 no-default-features = true
-features = ["codec-aom", "__internal_aom_generic_target"]
+features = ["codec-aom"]
 
 [workspace]
 members = [

--- a/libaom-sys/Cargo.toml
+++ b/libaom-sys/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "libaom-sys"
+version = "0.5.0"
+authors = ["Charles Samuels <ks@ks.ax>", "Paolo Barbolini <paolo@paolo565.org>", "Kornel <kornel@geekhood.net>"]
+edition = "2018"
+build = "build.rs"
+links = "aom"
+description="Builds and statically links libaom. Part of libavif-sys"
+keywords=["ffi","codec", "aom", "avif", "AV1"]
+repository="https://github.com/njaard/libavif-rs"
+documentation="https://docs.rs/libavif-sys"
+license="BSD-2-Clause"
+
+[features]
+__internal_aom_generic_target = []
+
+[build-dependencies]
+cmake = "0.1"
+
+[package.metadata.docs.rs]
+no-default-features = true
+features = ["__internal_aom_generic_target"]

--- a/libaom-sys/Cargo.toml
+++ b/libaom-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libaom-sys"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Charles Samuels <ks@ks.ax>", "Paolo Barbolini <paolo@paolo565.org>", "Kornel <kornel@geekhood.net>"]
 edition = "2018"
 build = "build.rs"
@@ -11,12 +11,5 @@ repository="https://github.com/njaard/libavif-rs"
 documentation="https://docs.rs/libavif-sys"
 license="BSD-2-Clause"
 
-[features]
-__internal_aom_generic_target = []
-
 [build-dependencies]
 cmake = "0.1"
-
-[package.metadata.docs.rs]
-no-default-features = true
-features = ["__internal_aom_generic_target"]

--- a/libaom-sys/build.rs
+++ b/libaom-sys/build.rs
@@ -23,7 +23,7 @@ fn main() {
 
     let dst = aom.build();
 
-    // CARGO_DEP_AOM_INCLUDE variable
+    // DEP_AOM_INCLUDE, DEP_AOM_PKGCONFIG variables
     println!("cargo:include={}", dst.join("include").display());
     println!("cargo:pkgconfig={}", dst.join("lib").join("pkgconfig").display());
 

--- a/libaom-sys/build.rs
+++ b/libaom-sys/build.rs
@@ -11,14 +11,11 @@ fn main() {
 
     let host = env::var("HOST").expect("HOST");
     let target = env::var("TARGET").expect("TARGET");
-    if host != target {
+    if env::var_os("DOCS_RS").is_some() {
+        aom.define("AOM_TARGET_CPU", "generic");
+    } else if host != target {
         let target_arch = env::var("CARGO_CFG_TARGET_ARCH").expect("CARGO_CFG_TARGET_ARCH");
         aom.define("AOM_TARGET_CPU", target_arch);
-    }
-
-    #[cfg(feature = "__internal_aom_generic_target")]
-    {
-        aom.define("AOM_TARGET_CPU", "generic");
     }
 
     let dst = aom.build();

--- a/libaom-sys/build.rs
+++ b/libaom-sys/build.rs
@@ -1,0 +1,32 @@
+use std::env;
+
+fn main() {
+    let mut aom = cmake::Config::new("vendor");
+    aom.profile("Release")
+        .define("ENABLE_DOCS", "0")
+        .define("ENABLE_EXAMPLES", "0")
+        .define("ENABLE_TESTDATA", "0")
+        .define("ENABLE_TESTS", "0")
+        .define("ENABLE_TOOLS", "0");
+
+    let host = env::var("HOST").expect("HOST");
+    let target = env::var("TARGET").expect("TARGET");
+    if host != target {
+        let target_arch = env::var("CARGO_CFG_TARGET_ARCH").expect("CARGO_CFG_TARGET_ARCH");
+        aom.define("AOM_TARGET_CPU", target_arch);
+    }
+
+    #[cfg(feature = "__internal_aom_generic_target")]
+    {
+        aom.define("AOM_TARGET_CPU", "generic");
+    }
+
+    let dst = aom.build();
+
+    // CARGO_DEP_AOM_INCLUDE variable
+    println!("cargo:include={}", dst.join("include").display());
+    println!("cargo:pkgconfig={}", dst.join("lib").join("pkgconfig").display());
+
+    println!("cargo:rustc-link-search=native={}", dst.join("lib").display());
+    println!("cargo:rustc-link-lib=static=aom");
+}

--- a/libaom-sys/build.rs
+++ b/libaom-sys/build.rs
@@ -22,8 +22,14 @@ fn main() {
 
     // DEP_AOM_INCLUDE, DEP_AOM_PKGCONFIG variables
     println!("cargo:include={}", dst.join("include").display());
-    println!("cargo:pkgconfig={}", dst.join("lib").join("pkgconfig").display());
+    println!(
+        "cargo:pkgconfig={}",
+        dst.join("lib").join("pkgconfig").display()
+    );
 
-    println!("cargo:rustc-link-search=native={}", dst.join("lib").display());
+    println!(
+        "cargo:rustc-link-search=native={}",
+        dst.join("lib").display()
+    );
     println!("cargo:rustc-link-lib=static=aom");
 }

--- a/libaom-sys/src/lib.rs
+++ b/libaom-sys/src/lib.rs
@@ -1,0 +1,2 @@
+//! There are no bindings. This is a link-only crate.
+//! Try <https://lib.rs/aom-sys> if you need bindings.

--- a/libavif-image/Cargo.toml
+++ b/libavif-image/Cargo.toml
@@ -25,8 +25,6 @@ codec-rav1e = ["libavif/codec-rav1e"]
 codec-dav1d = ["libavif/codec-dav1d"]
 codec-aom = ["libavif/codec-aom"]
 
-__internal_aom_generic_target = ["libavif/__internal_aom_generic_target"]
-
 [package.metadata.docs.rs]
 no-default-features = true
-features = ["codec-aom", "__internal_aom_generic_target"]
+features = ["codec-aom"]

--- a/libavif-sys/Cargo.toml
+++ b/libavif-sys/Cargo.toml
@@ -15,7 +15,7 @@ readme = "README.md"
 default = ["codec-dav1d", "codec-rav1e"]
 codec-rav1e = ["rav1e","nasm-rs"]
 codec-dav1d = []
-codec-aom = []
+codec-aom = ["libaom-sys"]
 
 __internal_aom_generic_target = []
 
@@ -23,6 +23,7 @@ __internal_aom_generic_target = []
 libc = "0.2"
 rav1e = { version = "=0.3.3", default-features = false, features = ["asm", "capi"], optional = true }
 nasm-rs = { version = "=0.1.7", optional = true }
+libaom-sys = { version = "0.5", path = "../libaom-sys", optional = true }
 
 [build-dependencies]
 cmake = "0.1"

--- a/libavif-sys/Cargo.toml
+++ b/libavif-sys/Cargo.toml
@@ -17,8 +17,6 @@ codec-rav1e = ["rav1e","nasm-rs"]
 codec-dav1d = []
 codec-aom = ["libaom-sys"]
 
-__internal_aom_generic_target = []
-
 [dependencies]
 libc = "0.2"
 rav1e = { version = "=0.3.3", default-features = false, features = ["asm", "capi"], optional = true }
@@ -30,4 +28,4 @@ cmake = "0.1"
 
 [package.metadata.docs.rs]
 no-default-features = true
-features = ["codec-aom", "__internal_aom_generic_target"]
+features = ["codec-aom"]

--- a/libavif-sys/build.rs
+++ b/libavif-sys/build.rs
@@ -23,11 +23,13 @@ fn main() {
 
     #[cfg(feature = "codec-aom")]
     {
-        let include = env::var_os("DEP_AOM_INCLUDE").expect("libaom-sys should have set pkgconfig path");
+        let include =
+            env::var_os("DEP_AOM_INCLUDE").expect("libaom-sys should have set pkgconfig path");
         avif.define("AVIF_CODEC_AOM", "1");
         avif.define("AOM_INCLUDE_DIR", include);
 
-        let pc_path = env::var_os("DEP_AOM_PKGCONFIG").expect("libaom-sys should have set pkgconfig path");
+        let pc_path =
+            env::var_os("DEP_AOM_PKGCONFIG").expect("libaom-sys should have set pkgconfig path");
         pc_paths.push(pc_path.into());
     }
 
@@ -46,7 +48,6 @@ fn main() {
             .define("AVIF_CODEC_LIBRARIES", "rav1e")
             .define("RAV1E_LIBRARY", "-rav1e");
     }
-
 
     pc_paths.push(out_dir.join("lib").join("pkgconfig"));
 

--- a/libavif-sys/build.rs
+++ b/libavif-sys/build.rs
@@ -28,9 +28,9 @@ fn main() {
         avif.define("AVIF_CODEC_AOM", "1");
         avif.define("AOM_INCLUDE_DIR", include);
 
-        let pc_path =
-            env::var_os("DEP_AOM_PKGCONFIG").expect("libaom-sys should have set pkgconfig path");
-        pc_paths.push(pc_path.into());
+        if let Some(pc_path) = env::var_os("DEP_AOM_PKGCONFIG") {
+            pc_paths.push(pc_path.into());
+        }
     }
 
     #[cfg(feature = "codec-rav1e")]

--- a/libavif-sys/src/lib.rs
+++ b/libavif-sys/src/lib.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "codec-aom")]
+extern crate libaom_sys; // mark it as used
+
 #[cfg(feature = "codec-rav1e")]
 pub use rav1e::capi::*;
 


### PR DESCRIPTION
It makes the crate smaller for people who don't use libaom. Helps Cargo build more crates in parallel if aom is used.

