### PR TITLE
No need to link when generating docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ opt-level = 2
 
 [package.metadata.docs.rs]
 no-default-features = true
-features = ["codec-aom"]
 
 [workspace]
 members = [

--- a/libaom-sys/build.rs
+++ b/libaom-sys/build.rs
@@ -1,6 +1,10 @@
 use std::env;
 
 fn main() {
+    if cfg!(rustdoc) || env::var_os("DOCS_RS").is_some() {
+        return;
+    }
+
     let mut aom = cmake::Config::new("vendor");
     aom.profile("Release")
         .define("ENABLE_DOCS", "0")
@@ -11,9 +15,7 @@ fn main() {
 
     let host = env::var("HOST").expect("HOST");
     let target = env::var("TARGET").expect("TARGET");
-    if env::var_os("DOCS_RS").is_some() {
-        aom.define("AOM_TARGET_CPU", "generic");
-    } else if host != target {
+    if host != target {
         let target_arch = env::var("CARGO_CFG_TARGET_ARCH").expect("CARGO_CFG_TARGET_ARCH");
         aom.define("AOM_TARGET_CPU", target_arch);
     }

--- a/libaom-sys/build.rs
+++ b/libaom-sys/build.rs
@@ -1,7 +1,7 @@
 use std::env;
 
 fn main() {
-    if cfg!(rustdoc) || env::var_os("DOCS_RS").is_some() {
+    if env::var_os("DOCS_RS").is_some() {
         return;
     }
 

--- a/libavif-image/Cargo.toml
+++ b/libavif-image/Cargo.toml
@@ -27,4 +27,4 @@ codec-aom = ["libavif/codec-aom"]
 
 [package.metadata.docs.rs]
 no-default-features = true
-features = ["codec-aom"]
+

--- a/libavif-sys/Cargo.toml
+++ b/libavif-sys/Cargo.toml
@@ -28,4 +28,4 @@ cmake = "0.1"
 
 [package.metadata.docs.rs]
 no-default-features = true
-features = ["codec-aom"]
+

--- a/libavif-sys/build.rs
+++ b/libavif-sys/build.rs
@@ -9,7 +9,7 @@ use cmake::Config;
 use std::ffi::OsString;
 
 fn main() {
-    if cfg!(rustdoc) || env::var_os("DOCS_RS").is_some() {
+    if env::var_os("DOCS_RS").is_some() {
         return;
     }
 

--- a/libavif-sys/build.rs
+++ b/libavif-sys/build.rs
@@ -9,6 +9,10 @@ use cmake::Config;
 use std::ffi::OsString;
 
 fn main() {
+    if cfg!(rustdoc) || env::var_os("DOCS_RS").is_some() {
+        return;
+    }
+
     let out_dir_ = env::var("OUT_DIR").unwrap();
     let out_dir = Path::new(&out_dir_);
     let mut _built_products_paths: Vec<PathBuf> = vec![];


### PR DESCRIPTION
I've checked that it doesn't affect `cargo test --doc`