### PR TITLE
Exclude unused files

### DIFF
--- a/libaom-sys/Cargo.toml
+++ b/libaom-sys/Cargo.toml
@@ -10,6 +10,7 @@ keywords=["ffi","codec", "aom", "avif", "AV1"]
 repository="https://github.com/njaard/libavif-rs"
 documentation="https://docs.rs/libavif-sys"
 license="BSD-2-Clause"
+exclude = ["/vendor/third_party/googletest/", "/vendor/test/*.cc", "/vendor/test/*.h", "/vendor/doc/", "/vendor/examples/", "*.dox"]
 
 [build-dependencies]
 cmake = "0.1"

--- a/libavif-sys/Cargo.toml
+++ b/libavif-sys/Cargo.toml
@@ -10,6 +10,7 @@ repository="https://github.com/njaard/libavif-rs"
 documentation="https://docs.rs/libavif-sys"
 license="BSD-2-Clause"
 readme = "README.md"
+exclude = ["/libavif/tests/", "/libavif/ext/", "/libavif/examples/", ".github"]
 
 [features]
 default = ["codec-dav1d", "codec-rav1e"]


### PR DESCRIPTION
Makes crate tarballs marginally smaller. I couldn't exclude anything from dav1d, because meson is guarding it too tightly.