### PR TITLE
Make libavif builds less fragile

### DIFF
--- a/libavif-sys/build.rs
+++ b/libavif-sys/build.rs
@@ -21,6 +21,8 @@ fn main() {
         .unwrap_or_default();
 
     avif.define("BUILD_SHARED_LIBS", "0");
+    // Required for clang 12 on macOS, and likely all future compilers libavif hasn't been tweaked for yet
+    avif.define("AVIF_ENABLE_WERROR", "0");
 
     if env::var_os("CI").is_some() {
         avif.very_verbose(true);


### PR DESCRIPTION
Updates libavif.

New version has an option to disable `-Werror`, which is necessary to make builds reliable. Otherwise it didn't compile with Apple clang 12, which introduced a new warning that wasn't relevant to libavif at all, but still broke the build, since libavif enabled all warnings for everything and `-Werror`.
