### PR TITLE
Make sure to destroy avifImage if decoding fails

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -14,6 +14,13 @@ impl AvifImage {
         unsafe { (*self.image).height }
     }
 
+    pub(crate) fn empty() -> Self {
+        unsafe {
+            let image = sys::avifImageCreateEmpty();
+            Self::from_raw(image)
+        }
+    }
+
     pub(crate) unsafe fn from_raw(image: *mut sys::avifImage) -> Self {
         debug_assert!(!image.is_null());
 
@@ -21,6 +28,10 @@ impl AvifImage {
     }
 
     pub(crate) fn inner(&self) -> *const sys::avifImage {
+        self.image
+    }
+
+    pub(crate) fn inner_mut(&mut self) -> *mut sys::avifImage {
         self.image
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,19 +32,19 @@ pub fn is_avif(avif_bytes: &[u8]) -> bool {
 }
 
 pub fn decode(avif_bytes: &[u8]) -> Result<AvifImage, Error> {
-    unsafe {
-        let raw = sys::avifROData {
-            data: avif_bytes.as_ptr(),
-            size: avif_bytes.len(),
-        };
+    let raw = sys::avifROData {
+        data: avif_bytes.as_ptr(),
+        size: avif_bytes.len(),
+    };
 
-        let image = sys::avifImageCreateEmpty();
+    let mut image = AvifImage::empty();
+    unsafe {
         let decoder = sys::avifDecoderCreate();
-        let result = sys::avifDecoderRead(decoder, image, &raw);
+        let result = sys::avifDecoderRead(decoder, image.inner_mut(), &raw);
         sys::avifDecoderDestroy(decoder);
         Error::code(result)?;
 
-        Ok(AvifImage::from_raw(image))
+        Ok(image)
     }
 }
 


### PR DESCRIPTION
While working on the previous PR I realized `avifImage` doesn't get freed if decoding fails.

Checking out the code in more detail it isn't as bad as I initially thought of, since the planes [get copied into our `avifImage`](https://github.com/AOMediaCodec/libavif/blob/e50032305454cabd8d9466ffb6f2f84f2f3d10c2/src/read.c#L2735) only after decoding succeeds. However [avifImage itself is heap allocated](https://github.com/AOMediaCodec/libavif/blob/3e735b860a1f1b7b6e3c5ff2777caf29f233e494/src/avif.c#L109-L123), so we would still be leaking some memory by not freeing it.

This implementation avoids creating an `avifImage` directly and instead creates an `AvifImage`, which freezes the underlying avifImage as soon as it's dropped.