### PR TITLE
Begin testing with rav1e v0.4.0-alpha

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,8 +67,8 @@ jobs:
             rust: beta
           - name: linux / nightly
             rust: nightly
-          - name: linux / 1.40.0
-            rust: 1.40.0
+          - name: linux / 1.44.0
+            rust: 1.44.0
           - name: macOS / stable
             os: macOS-latest
           - name: windows / stable

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![crates.io](https://img.shields.io/crates/v/libavif.svg)](https://crates.io/crates/libavif)
 [![Documentation](https://docs.rs/libavif/badge.svg)](https://docs.rs/libavif)
 [![BSD-2-Clause licensed](https://img.shields.io/crates/l/libavif.svg)](LICENSE)
-[![Rustc Version 1.40+](https://img.shields.io/badge/rustc-1.40+-lightgray.svg)](https://blog.rust-lang.org/2019/12/19/Rust-1.40.0.html)
+[![Rustc Version 1.44+](https://img.shields.io/badge/rustc-1.44+-lightgray.svg)](https://blog.rust-lang.org/2020/06/04/Rust-1.44.0.html)
 [![CI](https://github.com/njaard/libavif-rs/workflows/CI/badge.svg)](https://github.com/njaard/libavif-rs/actions?query=workflow%3ACI)
 
 Initial release of a high-level avif decoder.

--- a/libavif-image/README.md
+++ b/libavif-image/README.md
@@ -3,7 +3,7 @@
 [![crates.io](https://img.shields.io/crates/v/libavif-image.svg)](https://crates.io/crates/libavif-image)
 [![Documentation](https://docs.rs/libavif-image/badge.svg)](https://docs.rs/libavif-image)
 [![BSD-2-Clause licensed](https://img.shields.io/crates/l/libavif-image.svg)](../LICENSE)
-[![Rustc Version 1.40+](https://img.shields.io/badge/rustc-1.40+-lightgray.svg)](https://blog.rust-lang.org/2019/12/19/Rust-1.40.0.html)
+[![Rustc Version 1.44+](https://img.shields.io/badge/rustc-1.44+-lightgray.svg)](https://blog.rust-lang.org/2020/06/04/Rust-1.44.0.html)
 [![CI](https://github.com/njaard/libavif-rs/workflows/CI/badge.svg)](https://github.com/njaard/libavif-rs/actions?query=workflow%3ACI)
 
 This is a woefully incomplete utility crate

--- a/libavif-sys/Cargo.toml
+++ b/libavif-sys/Cargo.toml
@@ -20,7 +20,7 @@ codec-aom = ["libaom-sys"]
 
 [dependencies]
 libc = "0.2"
-rav1e = { version = "0.3.4", default-features = false, features = ["asm", "capi"], optional = true }
+rav1e = { version = "0.4.0-alpha", default-features = false, features = ["asm", "capi"], optional = true }
 libaom-sys = { version = "0.6", path = "../libaom-sys", optional = true }
 libdav1d-sys = { version = "0.1", path = "../libdav1d-sys", optional = true }
 

--- a/libavif-sys/README.md
+++ b/libavif-sys/README.md
@@ -3,7 +3,7 @@
 [![crates.io](https://img.shields.io/crates/v/libavif-sys.svg)](https://crates.io/crates/libavif-sys)
 [![Documentation](https://docs.rs/libavif-sys/badge.svg)](https://docs.rs/libavif-sys)
 [![BSD-2-Clause licensed](https://img.shields.io/crates/l/libavif-sys.svg)](../LICENSE)
-[![Rustc Version 1.40+](https://img.shields.io/badge/rustc-1.40+-lightgray.svg)](https://blog.rust-lang.org/2019/12/19/Rust-1.40.0.html)
+[![Rustc Version 1.44+](https://img.shields.io/badge/rustc-1.44+-lightgray.svg)](https://blog.rust-lang.org/2020/06/04/Rust-1.44.0.html)
 [![CI](https://github.com/njaard/libavif-rs/workflows/CI/badge.svg)](https://github.com/njaard/libavif-rs/actions?query=workflow%3ACI)
 
 AVIF is an image codec based on the next-generation


### PR DESCRIPTION
Changes: https://github.com/xiph/rav1e/releases/tag/v0.4.0-alpha