### PR TITLE
Fix MSVC build failure with `libaom`

### DIFF
--- a/libaom-sys/build.rs
+++ b/libaom-sys/build.rs
@@ -20,37 +20,18 @@ fn main() {
         aom.define("AOM_TARGET_CPU", target_arch);
     }
 
-    let using_msvc = target.ends_with("-msvc");
-
-    if using_msvc {
-        // aom's cmake build hides install target for msvc
-        aom.build_target("aom");
-    }
-
     let dst = aom.build();
 
-    // without install target these files are all over the place
-    if using_msvc {
-        let root = std::path::PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").expect("root"));
-        // DEP_AOM_INCLUDE variable
-        println!("cargo:include={}", root.join("vendor").display());
+    // DEP_AOM_INCLUDE, DEP_AOM_PKGCONFIG variables
+    println!("cargo:include={}", dst.join("include").display());
+    println!(
+        "cargo:pkgconfig={}",
+        dst.join("lib").join("pkgconfig").display()
+    );
 
-        println!(
-            "cargo:rustc-link-search=native={}",
-            dst.join("build").join("Release").display()
-        );
-    } else {
-        println!("cargo:include={}", dst.join("include").display());
-        // DEP_AOM_PKGCONFIG variable
-        println!(
-            "cargo:pkgconfig={}",
-            dst.join("lib").join("pkgconfig").display()
-        );
-
-        println!(
-            "cargo:rustc-link-search=native={}",
-            dst.join("lib").display()
-        );
-    }
+    println!(
+        "cargo:rustc-link-search=native={}",
+        dst.join("lib").display()
+    );
     println!("cargo:rustc-link-lib=static=aom");
 }


### PR DESCRIPTION
#24 has been [fixed by upstream](https://aomedia.googlesource.com/aom/+/29dd4e20cd6544a5a2f123736a01a720496e02ff) so the [original workaround](https://github.com/njaard/libavif-rs/commit/6c7ff4bf2219c4bcfe6796183e7c197398c94987) became unnecessary, and it's somehow not working on my machine:

```
running: "cmake" "libavif-rs/libavif-sys/libavif" "-G" "Visual Studio 16 2019" "-Thost=x64" "-Ax64" "-DBUILD_SHARED_LIBS=0" "-DAVIF_ENABLE_WERROR=0" "-DAVIF_CODEC_AOM=1" "-DAOM_INCLUDE_DIR=libavif-rs/libaom-sys/vendor" "-DCMAKE_PREFIX_PATH=" "-DCMAKE_INSTALL_PREFIX=libavif-rs/target/debug/build/libavif-sys-6d57f1058e9a9e31/out" "-DCMAKE_C_FLAGS= -nologo -MD -Brepro" "-DCMAKE_C_FLAGS_RELEASE= -nologo -MD -Brepro" "-DCMAKE_CXX_FLAGS= -nologo -MD -Brepro" "-DCMAKE_CXX_FLAGS_RELEASE= -nologo -MD -Brepro" "-DCMAKE_ASM_FLAGS= -nologo -MD -Brepro" "-DCMAKE_ASM_FLAGS_RELEASE= -nologo -MD -Brepro" "-DCMAKE_BUILD_TYPE=Release"
  -- Selecting Windows SDK version 10.0.19041.0 to target Windows 10.0.19042.
  -- The C compiler identification is MSVC 19.29.30133.0
  -- Detecting C compiler ABI info
  -- Detecting C compiler ABI info - done
  -- Check for working C compiler: C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.29.30133/bin/Hostx64/x64/cl.exe - skipped
  -- Detecting C compile features
  -- Detecting C compile features - done
  -- libavif: Enabling warnings for MSVC
  -- Checking for module 'libyuv'
  --
  -- libavif: libyuv not found; libyuv-based fast paths disabled.
  -- libavif: Codec enabled: aom (encode/decode)
  -- Checking for module 'aom'
  --
  -- Configuring incomplete, errors occurred!
  See also "libavif-rs/target/debug/build/libavif-sys-6d57f1058e9a9e31/out/build/CMakeFiles/CMakeOutput.log".

  --- stderr
  building libavif
  pc=""""; bp=""""
  CMake Error at C:/Users/andylizi/scoop/apps/cmake/3.21.3/share/cmake-3.21/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
    Could NOT find aom (missing: AOM_LIBRARY AOM_LIBRARIES) (found version "")
  Call Stack (most recent call first):
    C:/Users/andylizi/scoop/apps/cmake/3.21.3/share/cmake-3.21/Modules/FindPackageHandleStandardArgs.cmake:594 (_FPHSA_FAILURE_MESSAGE)
    cmake/Modules/Findaom.cmake:40 (find_package_handle_standard_args)
    CMakeLists.txt:398 (find_package)


  thread 'main' panicked at '
  command did not execute successfully, got: exit code: 1
```

I'm not quite familiar with CMake, this PR is the cleanest solution that works after several hours of fiddling around.