### PR TITLE
override CMAKE_INSTALL_LIBDIR for libaom

### DIFF
--- a/libaom-sys/build.rs
+++ b/libaom-sys/build.rs
@@ -11,7 +11,8 @@ fn main() {
         .define("ENABLE_EXAMPLES", "0")
         .define("ENABLE_TESTDATA", "0")
         .define("ENABLE_TESTS", "0")
-        .define("ENABLE_TOOLS", "0");
+        .define("ENABLE_TOOLS", "0")
+        .define("CMAKE_INSTALL_LIBDIR", "lib");
 
     let host = env::var("HOST").expect("HOST");
     let target = env::var("TARGET").expect("TARGET");


### PR DESCRIPTION
On my void linux install, it appears that `CMAKE_INSTALL_LIBDIR` defaults to `lib64`, which breaks libaom-sys, since it's looking for the static library in `lib`.

It looks like we're already overriding `CMAKE_INSTALL_LIBDIR` for `libavif-sys`, so we can just use the same pattern here.