### PR TITLE
feat: introduce BorrowedAvifImage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ libavif-sys = { version = "0.13.0", path = "libavif-sys", default-features = fal
 
 [dev-dependencies]
 image = "0.24"
+y4m = "0.7"
 
 [features]
 default = ["codec-dav1d", "codec-rav1e"]

--- a/examples/yuv4mpeg.rs
+++ b/examples/yuv4mpeg.rs
@@ -38,10 +38,7 @@ impl Y4MFrameConfig {
             self.bit_depth,
             self.yuv_format,
         )?;
-        img.set_y_row_bytes(self.row_bytes.0)
-            .set_u_row_bytes(self.row_bytes.1)
-            .set_v_row_bytes(self.row_bytes.2)
-            .set_chroma_sample_position(self.chroma_sample_position);
+        img.set_chroma_sample_position(self.chroma_sample_position);
         Some(img)
     }
 }
@@ -121,9 +118,9 @@ fn main() {
         let mut image = config.create_image().expect("couldn't create image");
         // These planes each have to be `row_bytes * height` bytes long
         image
-            .set_y(frame.get_y_plane())
-            .set_u(frame.get_u_plane())
-            .set_v(frame.get_v_plane());
+            .set_y(frame.get_y_plane(), config.row_bytes.0)
+            .set_u(frame.get_u_plane(), config.row_bytes.1)
+            .set_v(frame.get_v_plane(), config.row_bytes.2);
 
         encoder
             .add_image(&image, config.duration, AddImageFlags::NONE)

--- a/examples/yuv4mpeg.rs
+++ b/examples/yuv4mpeg.rs
@@ -31,7 +31,7 @@ impl Y4MFrameConfig {
         }
     }
 
-    fn create_image<'y, 'u, 'v, 'a>(&self) -> Option<BorrowedAvifImage<'y, 'u, 'v, 'a>> {
+    fn create_image<'data>(&self) -> Option<BorrowedAvifImage<'data>> {
         let mut img = BorrowedAvifImage::new(
             self.dimensions.0,
             self.dimensions.1,

--- a/examples/yuv4mpeg.rs
+++ b/examples/yuv4mpeg.rs
@@ -3,6 +3,7 @@ use std::time::Instant;
 use std::{env, fs, io};
 use y4m::Colorspace;
 
+/// This struct holds information about the y4m stream.
 #[derive(Debug)]
 struct Y4MFrameConfig {
     dimensions: (i32, i32),
@@ -118,6 +119,7 @@ fn main() {
 
         let frame_start_ts = Instant::now();
         let mut image = config.create_image().expect("couldn't create image");
+        // These planes each have to be `row_bytes * height` bytes long
         image
             .set_y(frame.get_y_plane())
             .set_u(frame.get_u_plane())

--- a/examples/yuv4mpeg.rs
+++ b/examples/yuv4mpeg.rs
@@ -1,0 +1,137 @@
+use libavif::{AddImageFlags, BorrowedAvifImage, ChromaSamplePosition, Encoder, YuvFormat};
+use std::time::Instant;
+use std::{env, fs, io};
+use y4m::Colorspace;
+
+struct Y4MFrameConfig {
+    dimensions: (i32, i32),
+    duration: u64,
+    timescale: u64,
+    row_bytes: (u32, u32, u32),
+    bit_depth: i32,
+    yuv_format: YuvFormat,
+    chroma_sample_position: ChromaSamplePosition,
+}
+
+impl Y4MFrameConfig {
+    fn new<R: io::Read>(decoder: &y4m::Decoder<R>) -> Self {
+        let (y_bytes, u_bytes, v_bytes) =
+            get_plane_row_bytes(decoder.get_width(), decoder.get_colorspace());
+        let (yuv_format, chroma_sample_position) = convert_colorspace(decoder.get_colorspace());
+        Self {
+            dimensions: (decoder.get_width() as _, decoder.get_height() as _),
+            duration: decoder.get_framerate().den as _,
+            timescale: decoder.get_framerate().num as _,
+            row_bytes: (y_bytes as _, u_bytes as _, v_bytes as _),
+            bit_depth: decoder.get_bit_depth() as _,
+            yuv_format,
+            chroma_sample_position,
+        }
+    }
+
+    fn create_image<'y, 'u, 'v, 'a>(&self) -> Option<BorrowedAvifImage<'y, 'u, 'v, 'a>> {
+        let mut img = BorrowedAvifImage::new(
+            self.dimensions.0,
+            self.dimensions.1,
+            self.bit_depth,
+            self.yuv_format,
+        )?;
+        img.set_y_row_bytes(self.row_bytes.0)
+            .set_u_row_bytes(self.row_bytes.1)
+            .set_v_row_bytes(self.row_bytes.2)
+            .set_chroma_sample_position(self.chroma_sample_position);
+        Some(img)
+    }
+}
+
+/// Converts the colorspace to a yuv-format and chroma-sample-position for the specific format
+fn convert_colorspace(colorspace: Colorspace) -> (YuvFormat, ChromaSamplePosition) {
+    match colorspace {
+        Colorspace::C420 | Colorspace::C420p10 | Colorspace::C420p12 | Colorspace::C420jpeg => {
+            (YuvFormat::Yuv420, Default::default())
+        }
+        Colorspace::C420mpeg2 => (YuvFormat::Yuv420, ChromaSamplePosition::Vertical),
+        Colorspace::C420paldv => (YuvFormat::Yuv420, ChromaSamplePosition::Colocated),
+        Colorspace::C422 | Colorspace::C422p10 | Colorspace::C422p12 => {
+            (YuvFormat::Yuv422, Default::default())
+        }
+        Colorspace::C444 | Colorspace::C444p10 | Colorspace::C444p12 => {
+            (YuvFormat::Yuv444, Default::default())
+        }
+        Colorspace::Cmono => (YuvFormat::Yuv400, Default::default()),
+    }
+}
+
+/// From y4m [get_plane_sizes][1]. Adapted to return the bytes per row.
+///
+/// [1]: https://github.com/image-rs/y4m/blob/7d1024083e84603cbd171fc849154035ff0592b8/src/lib.rs#L264-L286
+fn get_plane_row_bytes(width: usize, colorspace: Colorspace) -> (usize, usize, usize) {
+    let y_plane_size = width * colorspace.get_bytes_per_sample();
+
+    let c420_chroma_size = ((width + 1) / 2) * colorspace.get_bytes_per_sample();
+    let c422_chroma_size = ((width + 1) / 2) * colorspace.get_bytes_per_sample();
+
+    let c420_sizes = (y_plane_size, c420_chroma_size, c420_chroma_size);
+    let c422_sizes = (y_plane_size, c422_chroma_size, c422_chroma_size);
+    let c444_sizes = (y_plane_size, y_plane_size, y_plane_size);
+
+    match colorspace {
+        Colorspace::Cmono => (y_plane_size, 0, 0),
+        Colorspace::C420
+        | Colorspace::C420p10
+        | Colorspace::C420p12
+        | Colorspace::C420jpeg
+        | Colorspace::C420paldv
+        | Colorspace::C420mpeg2 => c420_sizes,
+        Colorspace::C422 | Colorspace::C422p10 | Colorspace::C422p12 => c422_sizes,
+        Colorspace::C444 | Colorspace::C444p10 | Colorspace::C444p12 => c444_sizes,
+    }
+}
+
+fn main() {
+    let input = env::args().nth(1).expect("input filename");
+    let output = env::args().nth(2).expect("output filename");
+    let input = fs::OpenOptions::new()
+        .read(true)
+        .open(&input)
+        .expect("couldn't open file");
+    let mut decoder = y4m::decode(input).expect("couldn't create decoder");
+
+    let config = Y4MFrameConfig::new(&decoder);
+
+    let mut encoder = Encoder::new();
+    encoder.set_timescale(config.timescale);
+
+    let start_ts = Instant::now();
+    let mut frame_counter = 1;
+    while let Ok(frame) = decoder.read_frame() {
+        let frame_start_ts = Instant::now();
+        let mut image = config.create_image().expect("couldn't create image");
+        image
+            .set_y(frame.get_y_plane())
+            .set_u(frame.get_u_plane())
+            .set_v(frame.get_v_plane());
+
+        encoder
+            .add_image(&image, config.duration, AddImageFlags::NONE)
+            .expect("couldn't add image");
+        eprintln!(
+            "Encoded frame {} in {:?}",
+            frame_counter,
+            Instant::now().duration_since(frame_start_ts)
+        );
+        frame_counter += 1;
+    }
+
+    let finish_start_ts = Instant::now();
+    eprintln!("Finishing encoding");
+    let data = encoder.finish().expect("couldn't finish encoding");
+    let finished_ts = Instant::now();
+    eprintln!(
+        "Finished encoding in {:?}, total time: {:?}",
+        finished_ts.duration_since(finish_start_ts),
+        finished_ts.duration_since(start_ts)
+    );
+
+    fs::write(&output, &*data).expect("couldn't write output");
+}

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1,4 +1,4 @@
-use crate::{AddImageFlags, AvifData, AvifImage, Error};
+use crate::{AddImageFlags, AvifData, AvifImageRef, Error};
 use libavif_sys as sys;
 
 /// AVIF image encoder
@@ -145,33 +145,33 @@ impl Encoder {
         self
     }
 
-    /// Encode an `AvifImage` using the settings from this `Encoder`
+    /// Encode an image using the settings from this `Encoder`
     ///
     /// Calling this function is the same as calling [`add_image`](Self::add_image) with
     /// [`AddImageFlags::SINGLE`](crate::AddImageFlags::SINGLE) and calling [`finish`](Self::finish).
-    pub fn encode(&self, image: &AvifImage) -> Result<AvifData<'static>, Error> {
+    pub fn encode<I: AvifImageRef>(&self, image_ref: &I) -> Result<AvifData<'static>, Error> {
         let mut data = Default::default();
         unsafe {
             Error::code(sys::avifEncoderWrite(
                 self.encoder,
-                image.inner(),
+                image_ref.image(),
                 &mut data,
             ))?;
             Ok(AvifData::from_raw(data))
         }
     }
 
-    /// Add an `AvifImage` to this `Encoder`.
-    pub fn add_image(
+    /// Add an image to this `Encoder`.
+    pub fn add_image<I: AvifImageRef>(
         &self,
-        image: &AvifImage,
+        image_ref: &I,
         duration_in_timescales: u64,
         flags: AddImageFlags,
     ) -> Result<(), super::Error> {
         unsafe {
             Error::code(sys::avifEncoderAddImage(
                 self.encoder,
-                image.inner(),
+                image_ref.image(),
                 duration_in_timescales,
                 flags.into(),
             ))

--- a/src/image/borrowed.rs
+++ b/src/image/borrowed.rs
@@ -1,0 +1,108 @@
+use std::marker::PhantomData;
+use std::ptr;
+
+use crate::{ChromaSamplePosition, YuvFormat};
+use libavif_sys as sys;
+use libavif_sys::avifImage;
+
+/// A readonly image that borrows its YUV+A planes' data.
+///
+/// **Safety:** This struct must never return a `*mut sys::avifImage`
+/// to make sure the plane data remains immutable.
+pub struct BorrowedAvifImage<'y, 'u, 'v, 'a> {
+    image: ptr::NonNull<sys::avifImage>,
+    _y_marker: PhantomData<&'y [u8]>,
+    _u_marker: PhantomData<&'u [u8]>,
+    _v_marker: PhantomData<&'v [u8]>,
+    _a_marker: PhantomData<&'a [u8]>,
+}
+
+impl<'y, 'u, 'v, 'a> BorrowedAvifImage<'y, 'u, 'v, 'a> {
+    pub fn new(width: i32, height: i32, depth: i32, format: YuvFormat) -> Option<Self> {
+        unsafe {
+            let mut image =
+                ptr::NonNull::new(sys::avifImageCreate(width, height, depth, format as u32))?;
+            image.as_mut().imageOwnsYUVPlanes = sys::AVIF_FALSE as sys::avifBool;
+            image.as_mut().imageOwnsAlphaPlane = sys::AVIF_FALSE as sys::avifBool;
+
+            Some(Self {
+                image,
+                _y_marker: Default::default(),
+                _u_marker: Default::default(),
+                _v_marker: Default::default(),
+                _a_marker: Default::default(),
+            })
+        }
+    }
+
+    /// Safety: Here, we turn an immutable reference into a mutable reference.
+    /// This is safe as long as we don't give out `*mut sys::avifImage`.
+    pub fn set_y(&mut self, data: &'y [u8]) -> &mut Self {
+        unsafe { self.image.as_mut().yuvPlanes[0] = data.as_ptr() as *mut _ }
+        self
+    }
+
+    /// Safety: See [set_y](Self::set_y).
+    pub fn set_u(&mut self, data: &'u [u8]) -> &mut Self {
+        unsafe { self.image.as_mut().yuvPlanes[1] = data.as_ptr() as *mut _ }
+        self
+    }
+
+    /// Safety: See [set_y](Self::set_y).
+    pub fn set_v(&mut self, data: &'v [u8]) -> &mut Self {
+        unsafe { self.image.as_mut().yuvPlanes[2] = data.as_ptr() as *mut _ }
+        self
+    }
+
+    /// Safety: See [set_y](Self::set_y).
+    pub fn set_a(&mut self, data: &'a [u8]) -> &mut Self {
+        unsafe { self.image.as_mut().alphaPlane = data.as_ptr() as *mut _ }
+        self
+    }
+
+    /// Set the bytes of this image for a row in the Y-plane (stride).
+    /// This _does not_ need to be equal to the width.
+    pub fn set_y_row_bytes(&mut self, row_bytes: u32) -> &mut Self {
+        unsafe { self.image.as_mut().yuvRowBytes[0] = row_bytes }
+        self
+    }
+
+    /// Set the bytes of this image for a row in the U-plane (stride).
+    /// This _does not_ need to be equal to the width.
+    pub fn set_u_row_bytes(&mut self, row_bytes: u32) -> &mut Self {
+        unsafe { self.image.as_mut().yuvRowBytes[1] = row_bytes }
+        self
+    }
+
+    /// Set the bytes of this image for a row in the V-plane (stride).
+    /// This _does not_ need to be equal to the width.
+    pub fn set_v_row_bytes(&mut self, row_bytes: u32) -> &mut Self {
+        unsafe { self.image.as_mut().yuvRowBytes[2] = row_bytes }
+        self
+    }
+
+    /// Set the bytes of this image for a row in the A-plane (stride).
+    /// This _does not_ need to be equal to the width.
+    pub fn set_a_row_bytes(&mut self, row_bytes: u32) -> &mut Self {
+        unsafe { self.image.as_mut().alphaRowBytes = row_bytes }
+        self
+    }
+
+    /// Set the chroma sample position
+    pub fn set_chroma_sample_position(&mut self, pos: ChromaSamplePosition) -> &mut Self {
+        unsafe { self.image.as_mut().yuvChromaSamplePosition = pos as _ }
+        self
+    }
+}
+
+impl Drop for BorrowedAvifImage<'_, '_, '_, '_> {
+    fn drop(&mut self) {
+        unsafe { sys::avifImageDestroy(self.image.as_ptr()) }
+    }
+}
+
+impl super::AvifImageRef for BorrowedAvifImage<'_, '_, '_, '_> {
+    unsafe fn image(&self) -> &avifImage {
+        self.image.as_ref()
+    }
+}

--- a/src/image/borrowed.rs
+++ b/src/image/borrowed.rs
@@ -35,56 +35,70 @@ impl<'y, 'u, 'v, 'a> BorrowedAvifImage<'y, 'u, 'v, 'a> {
         }
     }
 
-    /// Safety: Here, we turn an immutable reference into a mutable reference.
+    /// `row_bytes` is the number of bytes for one row in the image.
+    /// This _doesn't_ need to be equal to the width of this image.
+    ///
+    /// **Panics** If the length of `data` is less than `row_bytes * height`.
+    ///
+    /// **Safety:** Here, we turn an immutable reference into a mutable reference.
     /// This is safe as long as we don't give out `*mut sys::avifImage`.
-    pub fn set_y(&mut self, data: &'y [u8]) -> &mut Self {
-        unsafe { self.image.as_mut().yuvPlanes[0] = data.as_ptr() as *mut _ }
+    pub fn set_y(&mut self, data: &'y [u8], row_bytes: u32) -> &mut Self {
+        unsafe {
+            // Y-Plane must always have full width and height
+            assert!(data.len() as u32 >= row_bytes * self.image.as_ref().height);
+            self.image.as_mut().yuvRowBytes[0] = row_bytes;
+            self.image.as_mut().yuvPlanes[0] = data.as_ptr() as *mut _;
+        }
         self
     }
 
-    /// Safety: See [set_y](Self::set_y).
-    pub fn set_u(&mut self, data: &'u [u8]) -> &mut Self {
-        unsafe { self.image.as_mut().yuvPlanes[1] = data.as_ptr() as *mut _ }
+    /// `row_bytes` is the number of bytes for one row in the image.
+    /// This _doesn't_ need to be equal to the width of this image.
+    ///
+    /// **Panics** If `data` is too short.
+    /// For YUV420, the height only has to be half of the luma's height,
+    //  else it has to be as high as the luma plane.
+    ///
+    /// **Safety:** See [set_y](Self::set_y).
+    pub fn set_u(&mut self, data: &'u [u8], row_bytes: u32) -> &mut Self {
+        unsafe {
+            assert!(data.len() as u32 / row_bytes >= self.expected_chroma_height());
+            self.image.as_mut().yuvRowBytes[1] = row_bytes;
+            self.image.as_mut().yuvPlanes[1] = data.as_ptr() as *mut _;
+        }
         self
     }
 
-    /// Safety: See [set_y](Self::set_y).
-    pub fn set_v(&mut self, data: &'v [u8]) -> &mut Self {
-        unsafe { self.image.as_mut().yuvPlanes[2] = data.as_ptr() as *mut _ }
+    /// `row_bytes` is the number of bytes for one row in the image.
+    /// This _doesn't_ need to be equal to the width of this image.
+    ///
+    /// **Panics** If `data` is too short.
+    /// For YUV420, the height only has to be half of the luma's height,
+    /// else it has to be as high as the luma plane.
+    ///
+    /// **Safety:** See [set_y](Self::set_y).
+    pub fn set_v(&mut self, data: &'v [u8], row_bytes: u32) -> &mut Self {
+        unsafe {
+            assert!(data.len() as u32 / row_bytes >= self.expected_chroma_height());
+            self.image.as_mut().yuvRowBytes[2] = row_bytes;
+            self.image.as_mut().yuvPlanes[2] = data.as_ptr() as *mut _;
+        }
         self
     }
 
-    /// Safety: See [set_y](Self::set_y).
-    pub fn set_a(&mut self, data: &'a [u8]) -> &mut Self {
-        unsafe { self.image.as_mut().alphaPlane = data.as_ptr() as *mut _ }
-        self
-    }
-
-    /// Set the bytes of this image for a row in the Y-plane (stride).
-    /// This _does not_ need to be equal to the width.
-    pub fn set_y_row_bytes(&mut self, row_bytes: u32) -> &mut Self {
-        unsafe { self.image.as_mut().yuvRowBytes[0] = row_bytes }
-        self
-    }
-
-    /// Set the bytes of this image for a row in the U-plane (stride).
-    /// This _does not_ need to be equal to the width.
-    pub fn set_u_row_bytes(&mut self, row_bytes: u32) -> &mut Self {
-        unsafe { self.image.as_mut().yuvRowBytes[1] = row_bytes }
-        self
-    }
-
-    /// Set the bytes of this image for a row in the V-plane (stride).
-    /// This _does not_ need to be equal to the width.
-    pub fn set_v_row_bytes(&mut self, row_bytes: u32) -> &mut Self {
-        unsafe { self.image.as_mut().yuvRowBytes[2] = row_bytes }
-        self
-    }
-
-    /// Set the bytes of this image for a row in the A-plane (stride).
-    /// This _does not_ need to be equal to the width.
-    pub fn set_a_row_bytes(&mut self, row_bytes: u32) -> &mut Self {
-        unsafe { self.image.as_mut().alphaRowBytes = row_bytes }
+    /// `row_bytes` is the number of bytes for one row in the image.
+    /// This _doesn't_ need to be equal to the width of this image.
+    ///
+    /// **Panics** If the length of `data` is less than `row_bytes * height`.
+    ///
+    /// **Safety:** See [set_y](Self::set_y).
+    pub fn set_a(&mut self, data: &'a [u8], row_bytes: u32) -> &mut Self {
+        unsafe {
+            // alpha plane has the same height as the luma plane
+            assert!(data.len() as u32 / row_bytes >= self.image.as_ref().height);
+            self.image.as_mut().alphaRowBytes = row_bytes;
+            self.image.as_mut().alphaPlane = data.as_ptr() as *mut _;
+        }
         self
     }
 
@@ -92,6 +106,18 @@ impl<'y, 'u, 'v, 'a> BorrowedAvifImage<'y, 'u, 'v, 'a> {
     pub fn set_chroma_sample_position(&mut self, pos: ChromaSamplePosition) -> &mut Self {
         unsafe { self.image.as_mut().yuvChromaSamplePosition = pos as _ }
         self
+    }
+
+    /// Returns the expected height of the u and v planes for this image.
+    fn expected_chroma_height(&self) -> u32 {
+        unsafe {
+            if self.image.as_ref().yuvFormat == sys::AVIF_PIXEL_FORMAT_YUV420 {
+                // only in yuv420: the chroma size is half of the luma
+                (self.image.as_ref().height + 1) / 2
+            } else {
+                self.image.as_ref().height
+            }
+        }
     }
 }
 

--- a/src/image/chroma_position.rs
+++ b/src/image/chroma_position.rs
@@ -1,0 +1,15 @@
+use libavif_sys as sys;
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[repr(i32)]
+pub enum ChromaSamplePosition {
+    Unknown = sys::AVIF_CHROMA_SAMPLE_POSITION_UNKNOWN as _,
+    Vertical = sys::AVIF_CHROMA_SAMPLE_POSITION_VERTICAL as _,
+    Colocated = sys::AVIF_CHROMA_SAMPLE_POSITION_COLOCATED as _,
+}
+
+impl Default for ChromaSamplePosition {
+    fn default() -> Self {
+        Self::Unknown
+    }
+}

--- a/src/image/format.rs
+++ b/src/image/format.rs
@@ -1,3 +1,4 @@
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum YuvFormat {
     Yuv400 = 4,
     Yuv420 = 3,

--- a/src/image/mod.rs
+++ b/src/image/mod.rs
@@ -1,12 +1,12 @@
-mod owned;
 mod borrowed;
-mod format;
 mod chroma_position;
+mod format;
+mod owned;
 
-pub use owned::AvifImage;
 pub use borrowed::BorrowedAvifImage;
-pub use format::YuvFormat;
 pub use chroma_position::ChromaSamplePosition;
+pub use format::YuvFormat;
+pub use owned::AvifImage;
 
 use libavif_sys as sys;
 

--- a/src/image/mod.rs
+++ b/src/image/mod.rs
@@ -1,0 +1,19 @@
+mod owned;
+mod borrowed;
+mod format;
+mod chroma_position;
+
+pub use owned::AvifImage;
+pub use borrowed::BorrowedAvifImage;
+pub use format::YuvFormat;
+pub use chroma_position::ChromaSamplePosition;
+
+use libavif_sys as sys;
+
+pub trait AvifImageRef {
+    /// # Safety
+    /// * The returned image must be a valid reference
+    /// * The YUV and A planes must be null pointers _or_ point
+    /// to non-freed memory with enough capacity `(plane_row_bytes * height)`
+    unsafe fn image(&self) -> &sys::avifImage;
+}

--- a/src/image/owned.rs
+++ b/src/image/owned.rs
@@ -61,9 +61,10 @@ impl AvifImage {
     /// which must have not been freed yet.
     pub(crate) unsafe fn from_raw(image: *mut sys::avifImage) -> Self {
         // unwrap used for compatibility
-        Self { image: ptr::NonNull::new(image).unwrap() }
+        Self {
+            image: ptr::NonNull::new(image).unwrap(),
+        }
     }
-
 
     pub(crate) fn inner_mut(&mut self) -> *mut sys::avifImage {
         self.image.as_ptr()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,9 @@ pub use self::data::AvifData;
 pub use self::encoder::Encoder;
 pub use self::error::Error;
 pub use self::flags::AddImageFlags;
-pub use self::format::YuvFormat;
-pub use self::image::AvifImage;
+pub use self::image::{
+    AvifImage, AvifImageRef, BorrowedAvifImage, ChromaSamplePosition, YuvFormat,
+};
 pub use self::rgb::RgbPixels;
 use libavif_sys as sys;
 
@@ -13,7 +14,6 @@ mod data;
 mod encoder;
 mod error;
 mod flags;
-mod format;
 mod image;
 mod rgb;
 

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -5,6 +5,7 @@ use std::slice;
 use libavif_sys as sys;
 
 use crate::{AvifImage, Error, YuvFormat};
+use crate::image::AvifImageRef;
 
 pub struct RgbPixels<'a> {
     owned: bool,
@@ -112,17 +113,17 @@ impl<'a> From<AvifImage> for RgbPixels<'a> {
     }
 }
 
-impl<'a> From<&AvifImage> for RgbPixels<'a> {
-    fn from(image: &AvifImage) -> Self {
+impl<'a, I: AvifImageRef> From<&I> for RgbPixels<'a> {
+    fn from(image: &I) -> Self {
         unsafe {
             let mut rgb = sys::avifRGBImage::default();
             let raw_rgb = &mut rgb as *mut sys::avifRGBImage;
-            sys::avifRGBImageSetDefaults(raw_rgb, image.inner());
+            sys::avifRGBImageSetDefaults(raw_rgb, image.image());
             rgb.format = sys::AVIF_RGB_FORMAT_RGBA;
             rgb.depth = 8;
 
             sys::avifRGBImageAllocatePixels(raw_rgb);
-            sys::avifImageYUVToRGB(image.inner(), raw_rgb);
+            sys::avifImageYUVToRGB(image.image(), raw_rgb);
 
             RgbPixels::from_raw(rgb)
         }

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -4,8 +4,8 @@ use std::slice;
 
 use libavif_sys as sys;
 
-use crate::{AvifImage, Error, YuvFormat};
 use crate::image::AvifImageRef;
+use crate::{AvifImage, Error, YuvFormat};
 
 pub struct RgbPixels<'a> {
     owned: bool,


### PR DESCRIPTION
When encoding an image or an image sequence, one might already have the YUV(A) data in memory (for example when converting images/animations). If the data is already in a supported format, it's useless, to copy the data to the `AvifImage`.

To differentiate between owned and borrowed data, i created a struct that only holds borrowed data.

I'm not really sure if the set_y/u/v/a functions should be marked as unsafe since they turn `&[u8]` to `*mut u8`. The issue here isn't really turning `*const` to `*mut` since the encoder will only ever read the data, but rather that the encoder can't do bounds-checking. If the data is too short the encoder will happily read over the end of the data (and possibly trigger a segfault). I'm not sure if the assertions are enough to check the length.

I provided an [example][1] that recreates the yuv4mpeg handling of avifenc.

[1]: https://github.com/Nerixyz/libavif-rs/blob/2cb076016c402e9cbcd8f646b757fcbfcdab073f/examples/yuv4mpeg.rs