### PR TITLE
Split max/min quantizer settings for Encoder

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -78,7 +78,7 @@ impl Encoder {
         unsafe { (*self.encoder).minQuantizer as u8 }
     }
 
-    /// Set the quantizer value for the YUV channels
+    /// Set the max and min quantizer value for the YUV channels
     ///
     /// Must be between 0 and 63.
     ///
@@ -93,12 +93,42 @@ impl Encoder {
         self
     }
 
+    /// Set the max quantizer value for the YUV channels
+    ///
+    /// Must be between 0 and 63.
+    ///
+    /// * `0` - _lossless_
+    /// * `63` - _lowest quality_
+    pub fn set_max_quantizer(&mut self, max_quantizer: u8) -> &mut Self {
+        let max_quantizer =
+            (max_quantizer.min(63) as i32).max(unsafe { (*self.encoder).minQuantizer });
+        unsafe {
+            (*self.encoder).maxQuantizer = max_quantizer;
+        }
+        self
+    }
+
+    /// Set the min quantizer value for the YUV channels
+    ///
+    /// Must be between 0 and 63.
+    ///
+    /// * `0` - _lossless_
+    /// * `63` - _lowest quality_
+    pub fn set_min_quantizer(&mut self, min_quantizer: u8) -> &mut Self {
+        let min_quantizer =
+            (min_quantizer.min(63) as i32).min(unsafe { (*self.encoder).maxQuantizer });
+        unsafe {
+            (*self.encoder).minQuantizer = min_quantizer;
+        }
+        self
+    }
+
     /// Get quantizer value for the alpha channel
     pub fn quantizer_alpha(&self) -> u8 {
         unsafe { (*self.encoder).minQuantizerAlpha as u8 }
     }
 
-    /// Set the quantizer value for the alpha channel
+    /// Set the min and max quantizer value for the alpha channel
     ///
     /// Must be between 0 and 63.
     ///
@@ -109,6 +139,36 @@ impl Encoder {
         unsafe {
             (*self.encoder).minQuantizerAlpha = quantizer_alpha;
             (*self.encoder).maxQuantizerAlpha = quantizer_alpha;
+        }
+        self
+    }
+
+    /// Set the min quantizer value for the alpha channel
+    ///
+    /// Must be between 0 and 63.
+    ///
+    /// * `0` - _lossless_
+    /// * `63` - _lowest quality_
+    pub fn set_min_quantizer_alpha(&mut self, min_quantizer_alpha: u8) -> &mut Self {
+        let min_quantizer_alpha =
+            (min_quantizer_alpha.min(63) as i32).min(unsafe { (*self.encoder).maxQuantizerAlpha });
+        unsafe {
+            (*self.encoder).minQuantizerAlpha = min_quantizer_alpha;
+        }
+        self
+    }
+
+    /// Set the max quantizer value for the alpha channel
+    ///
+    /// Must be between 0 and 63.
+    ///
+    /// * `0` - _lossless_
+    /// * `63` - _lowest quality_
+    pub fn set_max_quantizer_alpha(&mut self, max_quantizer_alpha: u8) -> &mut Self {
+        let max_quantizer_alpha =
+            (max_quantizer_alpha.min(63) as i32).max(unsafe { (*self.encoder).minQuantizerAlpha });
+        unsafe {
+            (*self.encoder).maxQuantizerAlpha = max_quantizer_alpha;
         }
         self
     }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -78,7 +78,7 @@ impl Encoder {
         unsafe { (*self.encoder).minQuantizer as u8 }
     }
 
-    /// Set the max and min quantizer value for the YUV channels
+    /// Set the quantizer value for the YUV channels
     ///
     /// Must be between 0 and 63.
     ///
@@ -93,32 +93,18 @@ impl Encoder {
         self
     }
 
-    /// Set the max quantizer value for the YUV channels
+    /// Set the max and min quantizer value for the YUV channels
     ///
     /// Must be between 0 and 63.
     ///
     /// * `0` - _lossless_
     /// * `63` - _lowest quality_
-    pub fn set_max_quantizer(&mut self, max_quantizer: u8) -> &mut Self {
-        let max_quantizer =
-            (max_quantizer.min(63) as i32).max(unsafe { (*self.encoder).minQuantizer });
+    pub fn set_max_min_quantizer(&mut self, max_quantizer: u8, min_quantizer: u8) -> &mut Self {
+        let max_quantizer_i32 = max_quantizer.min(63).max(min_quantizer) as i32;
+        let min_quantizer_i32 = min_quantizer.min(63).min(max_quantizer) as i32;
         unsafe {
-            (*self.encoder).maxQuantizer = max_quantizer;
-        }
-        self
-    }
-
-    /// Set the min quantizer value for the YUV channels
-    ///
-    /// Must be between 0 and 63.
-    ///
-    /// * `0` - _lossless_
-    /// * `63` - _lowest quality_
-    pub fn set_min_quantizer(&mut self, min_quantizer: u8) -> &mut Self {
-        let min_quantizer =
-            (min_quantizer.min(63) as i32).min(unsafe { (*self.encoder).maxQuantizer });
-        unsafe {
-            (*self.encoder).minQuantizer = min_quantizer;
+            (*self.encoder).maxQuantizer = max_quantizer_i32;
+            (*self.encoder).minQuantizer = min_quantizer_i32;
         }
         self
     }
@@ -128,7 +114,7 @@ impl Encoder {
         unsafe { (*self.encoder).minQuantizerAlpha as u8 }
     }
 
-    /// Set the min and max quantizer value for the alpha channel
+    /// Set the quantizer value for the alpha channel
     ///
     /// Must be between 0 and 63.
     ///
@@ -143,32 +129,22 @@ impl Encoder {
         self
     }
 
-    /// Set the min quantizer value for the alpha channel
+    /// Set the max and min quantizer value for the alpha channel
     ///
     /// Must be between 0 and 63.
     ///
     /// * `0` - _lossless_
     /// * `63` - _lowest quality_
-    pub fn set_min_quantizer_alpha(&mut self, min_quantizer_alpha: u8) -> &mut Self {
-        let min_quantizer_alpha =
-            (min_quantizer_alpha.min(63) as i32).min(unsafe { (*self.encoder).maxQuantizerAlpha });
+    pub fn set_max_min_quantizer_alpha(
+        &mut self,
+        max_quantizer_alpha: u8,
+        min_quantizer_alpha: u8,
+    ) -> &mut Self {
+        let max_quantizer_alpha_i32 = max_quantizer_alpha.min(63).max(min_quantizer_alpha) as i32;
+        let min_quantizer_alpha_i32 = min_quantizer_alpha.min(63).min(max_quantizer_alpha) as i32;
         unsafe {
-            (*self.encoder).minQuantizerAlpha = min_quantizer_alpha;
-        }
-        self
-    }
-
-    /// Set the max quantizer value for the alpha channel
-    ///
-    /// Must be between 0 and 63.
-    ///
-    /// * `0` - _lossless_
-    /// * `63` - _lowest quality_
-    pub fn set_max_quantizer_alpha(&mut self, max_quantizer_alpha: u8) -> &mut Self {
-        let max_quantizer_alpha =
-            (max_quantizer_alpha.min(63) as i32).max(unsafe { (*self.encoder).minQuantizerAlpha });
-        unsafe {
-            (*self.encoder).maxQuantizerAlpha = max_quantizer_alpha;
+            (*self.encoder).maxQuantizerAlpha = max_quantizer_alpha_i32;
+            (*self.encoder).minQuantizerAlpha = min_quantizer_alpha_i32;
         }
         self
     }


### PR DESCRIPTION
splitting `max/min` quantizer is really useful. For example, encoding https://nextjs.org/showcase/hulu with quantizer `max: 50` `min: 25` is almost the same as `max: 50` `min:50`, but 2x faster.