### PR TITLE
Fix cmake version

### DIFF
--- a/libavif-sys/Cargo.toml
+++ b/libavif-sys/Cargo.toml
@@ -26,7 +26,7 @@ libaom-sys = { version = "0.12", path = "../libaom-sys", optional = true }
 libdav1d-sys = { version = "0.5", path = "../libdav1d-sys", optional = true }
 
 [build-dependencies]
-cmake = "0.1"
+cmake = "0.1.48"
 
 [package.metadata.docs.rs]
 no-default-features = true


### PR DESCRIPTION
libavif-sys build can fail with:

```markdown
error[E0599]: no method named `configure_arg` found for struct `Config` in the current scope
  --> ~/.cargo/registry/src/github.com-1ecc6299db9ec823/libavif-sys-0.13.1/build.rs:90:14
   |
90 |         avif.configure_arg("-T host=x64").configure_arg("-A Win32");
   |              ^^^^^^^^^^^^^ method not found in `Config`
```

due to allowing semver-incompatible **older** versions of cmake.