### PR TITLE
Fix wasm32-unknown-emscripten build problems

### DIFF
--- a/libavif-sys/build.rs
+++ b/libavif-sys/build.rs
@@ -44,15 +44,15 @@ fn main() {
     {
         let crate_dir_ = env::var("CARGO_MANIFEST_DIR").unwrap();
         let crate_dir = Path::new(&crate_dir_);
-        fs::create_dir_all(out_dir.join("include").join("rav1e")).expect("mkdir");
-        fs::copy(
-            crate_dir.join("rav1e.h"),
-            out_dir.join("include").join("rav1e").join("rav1e.h"),
-        )
-        .expect("copy rav1e.h");
+        let rav1e_include_dir = out_dir.join("include").join("rav1e");
+        fs::create_dir_all(&rav1e_include_dir).expect("mkdir");
+        fs::copy(crate_dir.join("rav1e.h"), rav1e_include_dir.join("rav1e.h"))
+            .expect("copy rav1e.h");
 
         avif.define("AVIF_CODEC_RAV1E", "1")
             .define("AVIF_CODEC_LIBRARIES", "rav1e")
+            // required by `emcmake cmake`
+            .define("RAV1E_INCLUDE_DIR", rav1e_include_dir)
             .define("RAV1E_LIBRARY", "-rav1e");
     }
 

--- a/libdav1d-sys/build.rs
+++ b/libdav1d-sys/build.rs
@@ -23,6 +23,9 @@ fn main() {
             .arg("--cross-file")
             .arg("aarch64-unknown-linux-gnu.meson");
     }
+    if target == "wasm32-unknown-emscripten" {
+        meson.arg("--cross-file").arg("wasm32-unknown-emscripten.meson");
+    }
 
     let s = meson
         .arg("--default-library=static")

--- a/libdav1d-sys/build.rs
+++ b/libdav1d-sys/build.rs
@@ -24,7 +24,9 @@ fn main() {
             .arg("aarch64-unknown-linux-gnu.meson");
     }
     if target == "wasm32-unknown-emscripten" {
-        meson.arg("--cross-file").arg("wasm32-unknown-emscripten.meson");
+        meson
+            .arg("--cross-file")
+            .arg("wasm32-unknown-emscripten.meson");
     }
 
     let s = meson

--- a/libdav1d-sys/wasm32-unknown-emscripten.meson
+++ b/libdav1d-sys/wasm32-unknown-emscripten.meson
@@ -1,0 +1,17 @@
+[binaries]
+c = 'emcc'
+cpp = 'em++'
+ar = 'emar'
+
+[built-in options]
+c_args = []
+c_link_args = ['-sEXPORT_ALL=1']
+cpp_args = []
+cpp_link_args = ['-sEXPORT_ALL=1']
+
+[host_machine]
+
+system = 'emscripten'
+cpu_family = 'wasm32'
+cpu = 'wasm32'
+endian = 'little'


### PR DESCRIPTION
Can't build `libavif-sys` with `rav1e` + `dav1d` to `wasm32-unknown-emscripten`.
This should fix it.