### PR TITLE
Use SemVer Build Metadata to convey the version of the underlying library

### DIFF
--- a/libaom-sys/Cargo.toml
+++ b/libaom-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libaom-sys"
-version = "0.15.0"
+version = "0.15.0+libaom.3.8.1"
 authors = ["Charles Samuels <ks@ks.ax>", "Paolo Barbolini <paolo@paolo565.org>", "Kornel <kornel@geekhood.net>"]
 edition = "2018"
 build = "build.rs"

--- a/libavif-sys/Cargo.toml
+++ b/libavif-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libavif-sys"
-version = "0.15.0"
+version = "0.15.0+libavif.1.0.3"
 authors = ["Charles Samuels <ks@ks.ax>", "Paolo Barbolini <paolo@paolo565.org>"]
 edition = "2021"
 rust-version = "1.63"

--- a/libdav1d-sys/Cargo.toml
+++ b/libdav1d-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libdav1d-sys"
-version = "0.6.0"
+version = "0.6.0+libdav1d.1.3.0"
 authors = ["Charles Samuels <ks@ks.ax>", "Paolo Barbolini <paolo@paolo565.org>", "Kornel <kornel@geekhood.net>"]
 edition = "2021"
 build = "build.rs"


### PR DESCRIPTION
I think this change would make it a bit more obvious to external users what version of the underlying vendored C library they're getting from crates.io.
Many other crates do this, for example [`zstd-sys`](https://crates.io/crates/zstd-sys/2.0.9+zstd.1.5.5)