### PR TITLE
Bump libdav1d to v1.4.2

### DIFF
--- a/libdav1d-sys/Cargo.toml
+++ b/libdav1d-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libdav1d-sys"
-version = "0.7.0+libdav1d.1.4.1"
+version = "0.7.0+libdav1d.1.4.2"
 authors = ["Charles Samuels <ks@ks.ax>", "Paolo Barbolini <paolo@paolo565.org>", "Kornel <kornel@geekhood.net>"]
 edition = "2021"
 build = "build.rs"

--- a/libdav1d-sys/ffi.rs
+++ b/libdav1d-sys/ffi.rs
@@ -15,7 +15,7 @@ pub const DAV1D_API_VERSION_MINOR: u32 = 0;
 pub const DAV1D_API_VERSION_PATCH: u32 = 0;
 pub const DAV1D_MAX_THREADS: u32 = 256;
 pub const DAV1D_MAX_FRAME_DELAY: u32 = 256;
-pub type va_list = __builtin_va_list;
+pub type va_list = [u64; 4usize];
 #[doc = " A reference-counted object wrapper for a user-configurable pointer."]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -677,7 +677,7 @@ pub struct Dav1dLogger {
         unsafe extern "C" fn(
             cookie: *mut ::std::os::raw::c_void,
             format: *const ::std::os::raw::c_char,
-            ap: *mut __va_list_tag,
+            ap: va_list,
         ),
     >,
 }


### PR DESCRIPTION
Changelog: https://code.videolan.org/videolan/dav1d/-/releases/1.4.2