### PR TITLE
add x86_64-w64-mingw32 target to libdav1d-sys

### DIFF
--- a/libdav1d-sys/build.rs
+++ b/libdav1d-sys/build.rs
@@ -18,6 +18,9 @@ fn main() {
     if target == "i686-pc-windows-msvc" {
         meson.arg("--cross-file").arg("i686-win-msvc.meson");
     }
+    if target == "x86_64-pc-windows-gnu" {
+        meson.arg("--cross-file").arg("x86_64-w64-mingw32.meson");
+    }
     if target == "aarch64-unknown-linux-gnu" {
         meson
             .arg("--cross-file")

--- a/libdav1d-sys/x86_64-w64-mingw32.meson
+++ b/libdav1d-sys/x86_64-w64-mingw32.meson
@@ -1,0 +1,16 @@
+[binaries]
+c = 'x86_64-w64-mingw32-gcc'
+cpp = 'x86_64-w64-mingw32-g++'
+ar = 'x86_64-w64-mingw32-ar'
+strip = 'x86_64-w64-mingw32-strip'
+windres = 'x86_64-w64-mingw32-windres'
+exe_wrapper = 'wine'
+
+[properties]
+c_link_args = ['-static-libgcc']
+
+[host_machine]
+system = 'windows'
+cpu_family = 'x86_64'
+cpu = 'x86_64'
+endian = 'little'


### PR DESCRIPTION
The cross compile target for compiling windows x86_64 on linux using mingw for libdav1d was missing.
This pull request adds it so that a library that uses libavif-rs as a dependency and wants to cross compile to windows on linux can do so without the build failing to link.

The meson config for mingw32 w64 was taken directly from the videolan repository for libdav1d.