### PR TITLE
Apply wasm32-wasi-preview1-threads to wasm32-wasip1-threads rename

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
             features: '--no-default-features --features codec-aom'
           - name: wasi / stable codec-rav1e
             os: macOS-14
-            target: 'wasm32-wasi-preview1-threads'
+            target: 'wasm32-wasip1-threads'
             # libaom does not support wasi due to https://github.com/WebAssembly/wasi-libc/issues/432
             features: '--no-default-features --features codec-rav1e'
 
@@ -177,7 +177,7 @@ jobs:
           CXX: 'emcc'
 
       - name: Check wasi
-        if: matrix.target == 'wasm32-wasi-preview1-threads'
+        if: matrix.target == 'wasm32-wasip1-threads'
         run: |
           wget https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-21/wasi-sdk-21.0-macos.tar.gz
           tar -xvf wasi-sdk-21.0-macos.tar.gz

--- a/libaom-sys/build.rs
+++ b/libaom-sys/build.rs
@@ -53,7 +53,7 @@ fn main() {
                           ),
                       );
                 }
-                "wasm32-wasi" | "wasm32-wasi-preview1-threads" => {
+                "wasm32-wasi" | "wasm32-wasi-preview1-threads" | "wasm32-wasip1-threads" => {
                     aom.define("AOM_TARGET_CPU", "generic")
                         .define("CONFIG_ACCOUNTING", "1")
                         .define("CONFIG_INSPECTION", "1")


### PR DESCRIPTION
Blindly applying the rename in https://doc.rust-lang.org/rustc/platform-support/wasm32-wasip1-threads.html to see if it fixes the rav1e CI